### PR TITLE
Create run configuration

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -27,7 +27,6 @@
   <depends>com.intellij.modules.lang</depends>
   <!--<depends>com.github.spullara.mustache.java</depends>-->
 
-
   <extensions defaultExtensionNs="com.intellij">
     <applicationConfigurable instance="com.slalom.aws.avs.sutr.conf.SutrConfigPanel"/>
     <fileTypeFactory implementation="com.slalom.aws.avs.sutr.SutrFileTypeFactory" />
@@ -41,6 +40,7 @@
     <lang.findUsagesProvider language="sutr" implementationClass="com.slalom.aws.avs.sutr.SutrFindUsagesProvider" />
     <completion.contributor language="sutr" implementationClass="com.slalom.aws.avs.sutr.SutrCompletionContributor" />
     <lang.commenter language="sutr" implementationClass="com.slalom.aws.avs.sutr.psi.impl.SutrCommenter" />
+    <configurationType implementation="com.slalom.aws.avs.sutr.conf.SutrRunConfigType"/>
     <!--<colorSettingsPage implementation="com.slalom.aws.avs.sutr.SutrColorSettingsPage" />-->
     <!--<colorSettingsPage implementation="com.slalom.aws.avs.utr.UtrColorSettingsPage" />-->
   </extensions>

--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin version="2">
   <id>com.slalom.idea.aws.avs.sutr</id>
   <name>Sutr Language Plugin</name>
-  <version>0.7.4</version>
+  <version>0.7.6</version>
   <vendor email="stryderc@slalom.com" url="http://www.slalom.com">Slalom</vendor>
 
   <description><![CDATA[
@@ -9,8 +9,10 @@
     ]]></description>
 
   <change-notes><![CDATA[
-    0.7.4 - Settings panel added. Can now configure output paths.
-    0.7.3 - Support added for 'from <file> import <typeName>' statements. '_' now valid for Type name declarations.
+    0.7.6 - Support added for importing types with relative path.<br>
+    0.7.5 - Added run configuration to allow generation of Ask as part of a build.<br>
+    0.7.4 - Settings panel added. Can now configure output paths.<br>
+    0.7.3 - Support added for 'from <file> import <typeName>' statements. '_' now valid for Type name declarations.<br>
     0.7.2 - Implement error annotations for duplicate types. Pop up messages and compilation validation added.<br>
     0.7.1 - Add generator for Node/python. Copy Custom Type List action added.<br>
     0.7.0 - Implement error annotations for types, slots, and duplicates. Rename refactoring enabled. Commenter hot key enabled.<br>

--- a/example.sutr
+++ b/example.sutr
@@ -1,21 +1,21 @@
 # This is a comment
 
-type MyCustomType = [
-	Jump
-	Run
-	Walk
+type MyCustomType [
+	Jump,
+	Run,
+	Walk,
 	stand
 	#comments can go here
 ]
 
-literal MyLiteral = [
-	Jump and run
+literal MyLiteral [
+    Jump and run
 	Run
 	Walk and do a thing
 ]
 
-action MyAction(MyCustomType Action, MyLiteral Phrase, DATE Date){
+def MyAction(MyCustomType Action, MyLiteral Phrase, date Date){
 	Remember to do {Action} or {Phrase} on {Date}
 	#comments can go here
 	Remind me to {Action} and {Phrase} on {Date}
-}
+} => MyFunction

--- a/src/com/slalom/aws/avs/sutr/Sutr.bnf
+++ b/src/com/slalom/aws/avs/sutr/Sutr.bnf
@@ -50,13 +50,13 @@ file_name ::= ('../'|'./')*NAME('/'NAME)*
 custom_type ::= 'slotType' type_name custom_type_items
 {extends="com.slalom.aws.avs.sutr.psi.impl.SutrReferenceImpl" implements="com.slalom.aws.avs.sutr.psi.SutrTypeDefinitionReference" }
 
-custom_type_items ::= LS custom_type_item (EOL custom_type_item)* RS {pin=1}
+custom_type_items ::= LS custom_type_item ("," custom_type_item)* RS {pin=1}
 custom_type_item ::= (NAME|WORD)*
 
 literal_type ::= 'literal' type_name literal_phrases
 {extends="com.slalom.aws.avs.sutr.psi.impl.SutrReferenceImpl" implements="com.slalom.aws.avs.sutr.psi.SutrTypeDefinitionReference" }
 
-literal_phrases ::= LS literal_phrase (EOL literal_phrase )* RS {pin=1}
+literal_phrases ::= LS literal_phrase ("," literal_phrase )* RS {pin=1}
 literal_phrase ::= (NAME|WORD)*
 
 object ::= 'def' sutr_name sutr_params body function_pointer {pin=3}

--- a/src/com/slalom/aws/avs/sutr/Sutr.bnf
+++ b/src/com/slalom/aws/avs/sutr/Sutr.bnf
@@ -45,7 +45,7 @@ private top_level_recover ::= !('def' | 'slotType' | 'literal' | 'from')
 import_stmt ::= 'from' file_name IMPORT type_name
 {methods=[getTypeReferences resolveReference]}
 
-file_name ::= NAME
+file_name ::= ('../'|'./')*NAME('/'NAME)*
 
 custom_type ::= 'slotType' type_name custom_type_items
 {extends="com.slalom.aws.avs.sutr.psi.impl.SutrReferenceImpl" implements="com.slalom.aws.avs.sutr.psi.SutrTypeDefinitionReference" }

--- a/src/com/slalom/aws/avs/sutr/Sutr.bnf
+++ b/src/com/slalom/aws/avs/sutr/Sutr.bnf
@@ -50,13 +50,13 @@ file_name ::= NAME
 custom_type ::= 'slotType' type_name custom_type_items
 {extends="com.slalom.aws.avs.sutr.psi.impl.SutrReferenceImpl" implements="com.slalom.aws.avs.sutr.psi.SutrTypeDefinitionReference" }
 
-custom_type_items ::= LS custom_type_item (',' custom_type_item)* RS {pin=1}
-custom_type_item ::= (NAME|WORD)
+custom_type_items ::= LS custom_type_item (EOL custom_type_item)* RS {pin=1}
+custom_type_item ::= (NAME|WORD)*
 
 literal_type ::= 'literal' type_name literal_phrases
 {extends="com.slalom.aws.avs.sutr.psi.impl.SutrReferenceImpl" implements="com.slalom.aws.avs.sutr.psi.SutrTypeDefinitionReference" }
 
-literal_phrases ::= LS literal_phrase (',' literal_phrase )* RS {pin=1}
+literal_phrases ::= LS literal_phrase (EOL literal_phrase )* RS {pin=1}
 literal_phrase ::= (NAME|WORD)*
 
 object ::= 'def' sutr_name sutr_params body function_pointer {pin=3}

--- a/src/com/slalom/aws/avs/sutr/actions/GenerateVoiceModel.java
+++ b/src/com/slalom/aws/avs/sutr/actions/GenerateVoiceModel.java
@@ -29,60 +29,11 @@ public class GenerateVoiceModel extends SutrAction {
         if (project == null || sutrFiles.isEmpty()) return;
 
         try {
-            SutrConfigProvider sutrConfigProvider = SutrPluginUtil.getConfigProvider();
-
-            final StringBuilder buildIntent = SutrGenerator.buildIntent(sutrFiles);
-            final StringBuilder buildUtterances = SutrGenerator.buildUtterances(sutrFiles);
-            final StringBuilder buildHandler = SutrGenerator.buildHandler(sutrFiles, sutrConfigProvider.getCurrentHandlerTemplatePath());
-            final StringBuilder buildCustomTypes = SutrGenerator.buildSutrCustomTypes(sutrFiles);
-
-            String handlerPath = sutrConfigProvider.getHandlerOutputLocation();
-            String intentPath = sutrConfigProvider.getIntentOutputLocation();
-            String utterancesPath = sutrConfigProvider.getUtterancesOutputLocation();
-            String customTypesPath = sutrConfigProvider.getCustomTypesOutputLocation();
-
-            WriteContentToFile(buildHandler, handlerPath);
-            WriteContentToFile(buildIntent, intentPath);
-            WriteContentToFile(buildUtterances, utterancesPath);
-            WriteContentToFile(buildCustomTypes, customTypesPath);
-
+            SutrGenerator.genererateAsk(sutrFiles);
             ActionUtil.ShowInfoMessage("ASK model generated.", e);
 
         } catch (SutrGeneratorException e1) {
             ActionUtil.ShowErrorMessage(e1.getMessage(), e);
         }
     }
-
-    private void WriteContentToFile(StringBuilder fileContent, String filePath) throws SutrGeneratorException {
-
-        File file = new File(filePath);
-
-        try {
-            File dir = Paths.get(filePath).getParent().toFile();
-
-            boolean dirExists = dir.isDirectory();
-            if(!dirExists){
-               dirExists =  dir.mkdirs();
-            }
-
-            if(!dirExists){
-                throw new SutrGeneratorException("Unable to create directory [" + dir.toString() + "]");
-            }
-
-            if((file.exists()|| file.createNewFile())){
-                FileWriter writer = new FileWriter(file);
-                writer.write(fileContent.toString());
-                writer.close();
-            }
-            else{
-                throw new SutrGeneratorException("Unable to create file [" + file.toPath().toString() + "]");
-            }
-
-
-        } catch (IOException e1) {
-            e1.printStackTrace();
-        }
-
-    }
-
 }

--- a/src/com/slalom/aws/avs/sutr/actions/GenerateVoiceModel.java
+++ b/src/com/slalom/aws/avs/sutr/actions/GenerateVoiceModel.java
@@ -34,14 +34,17 @@ public class GenerateVoiceModel extends SutrAction {
             final StringBuilder buildIntent = SutrGenerator.buildIntent(sutrFiles);
             final StringBuilder buildUtterances = SutrGenerator.buildUtterances(sutrFiles);
             final StringBuilder buildHandler = SutrGenerator.buildHandler(sutrFiles, sutrConfigProvider.getCurrentHandlerTemplatePath());
+            final StringBuilder buildCustomTypes = SutrGenerator.buildSutrCustomTypes(sutrFiles);
 
             String handlerPath = sutrConfigProvider.getHandlerOutputLocation();
             String intentPath = sutrConfigProvider.getIntentOutputLocation();
             String utterancesPath = sutrConfigProvider.getUtterancesOutputLocation();
+            String customTypesPath = sutrConfigProvider.getCustomTypesOutputLocation();
 
             WriteContentToFile(buildHandler, handlerPath);
             WriteContentToFile(buildIntent, intentPath);
             WriteContentToFile(buildUtterances, utterancesPath);
+            WriteContentToFile(buildCustomTypes, customTypesPath);
 
             ActionUtil.ShowInfoMessage("ASK model generated.", e);
 

--- a/src/com/slalom/aws/avs/sutr/actions/SutrGenerator.java
+++ b/src/com/slalom/aws/avs/sutr/actions/SutrGenerator.java
@@ -307,11 +307,11 @@ public class SutrGenerator {
     static StringBuilder buildHandler(List<SutrFile> sutrFiles, String language) throws SutrGeneratorException {
         SutrConfigProvider config = SutrPluginUtil.getConfigProvider();
 
-//            String handlerTemplateLocation = config.handlerTemplateLocation;
-
         String template = config.getCurrentHandlerTemplatePath();
-
-        //String template =  "C:\\Users\\stryderc\\dev\\sources\\sutr-io\\src\\resources\\templates\\python.mustache";
+        String defaultTemplate = getDefaultTemplatePath(template);
+        if (defaultTemplate != null) {
+            template = defaultTemplate;
+        }
 
         SutrMustacheModelBuilder modelBuilder = new SutrMustacheModelBuilder(template);
         try {
@@ -322,6 +322,20 @@ public class SutrGenerator {
         }
 
         return new StringBuilder();
+    }
+
+    private static String getDefaultTemplatePath(String template) {
+        String defaultTemplateLocation = null;
+        if (Objects.equals(template, SutrConfigProvider.DEFAULT_JAVASCRIPT_TEMPLATE_PATH)) {
+            ClassLoader classLoader = SutrGenerator.class.getClassLoader();
+            defaultTemplateLocation = classLoader.getResource("templates/javascript.mustache").getFile();
+        }
+        else if (Objects.equals(template, SutrConfigProvider.DEFAULT_PYTHON_TEMPLATE_PATH)) {
+            ClassLoader classLoader = SutrGenerator.class.getClassLoader();
+            defaultTemplateLocation = classLoader.getResource("templates/python.mustache").getFile();
+        }
+
+        return defaultTemplateLocation;
     }
 
     public static class BuildSutrDefinitions {

--- a/src/com/slalom/aws/avs/sutr/actions/SutrGenerator.java
+++ b/src/com/slalom/aws/avs/sutr/actions/SutrGenerator.java
@@ -39,6 +39,33 @@ public class SutrGenerator {
         return new StringBuilder(gson.toJson(intents));
     }
 
+    static StringBuilder buildSutrCustomTypes(List<SutrFile> sutrFiles) throws SutrGeneratorException {
+
+        BuildSutrDefinitions sutrDefinitions = new BuildSutrDefinitions(sutrFiles).invoke();
+
+        if (sutrDefinitions.getSutrObjectList().isEmpty()) {
+            throw new SutrGeneratorException("No Sutr definitions found");
+        }
+
+        StringBuilder output = new StringBuilder();
+        for (Map.Entry<String, SutrCustomType> sutrCustomType : sutrDefinitions.getSutrCustomTypeKeys().entrySet()) {
+            output.append(sutrCustomType.getKey()).append("\n");
+            output.append(buildCustomTypeItems(sutrCustomType.getValue()));
+            output.append("<<<<<\n");
+        }
+
+        for (Map.Entry<String, SutrLiteralType> sutrLiteralType : sutrDefinitions.getSutrLiteralTypeKeys().entrySet()) {
+            output.append(sutrLiteralType.getKey()).append("\n");
+            for (final SutrLiteralPhrase sutrLiteralPhrase : sutrLiteralType.getValue().getLiteralPhrases().getLiteralPhraseList()) {
+                output.append(sutrLiteralPhrase.getText()).append("\n");
+            }
+
+            output.append("<<<<<\n");
+        }
+
+        return output;
+    }
+
     public static List<SutrIntentModel> GetModels(BuildSutrDefinitions sutrDefinitions) throws SutrGeneratorException {
         List<SutrIntentModel> sutrIntentModelCollection = new ArrayList<>();
 
@@ -282,9 +309,9 @@ public class SutrGenerator {
 
 //            String handlerTemplateLocation = config.handlerTemplateLocation;
 
-//            String template = config.getCurrentHandlerTemplatePath();
+        String template = config.getCurrentHandlerTemplatePath();
 
-        String template =  "C:\\Users\\stryderc\\dev\\sources\\sutr-io\\src\\resources\\templates\\python.mustache";
+        //String template =  "C:\\Users\\stryderc\\dev\\sources\\sutr-io\\src\\resources\\templates\\python.mustache";
 
         SutrMustacheModelBuilder modelBuilder = new SutrMustacheModelBuilder(template);
         try {

--- a/src/com/slalom/aws/avs/sutr/actions/SutrGenerator.java
+++ b/src/com/slalom/aws/avs/sutr/actions/SutrGenerator.java
@@ -80,9 +80,12 @@ public class SutrGenerator {
         for (Map.Entry<String, SutrLiteralType> sutrLiteralType : sutrDefinitions.getSutrLiteralTypeKeys().entrySet()) {
             output.append(sutrLiteralType.getKey()).append("\n");
             for (final SutrLiteralPhrase sutrLiteralPhrase : sutrLiteralType.getValue().getLiteralPhrases().getLiteralPhraseList()) {
-                output.append(sutrLiteralPhrase.getText()).append("\n");
-            }
+                String literalPhrases = sutrLiteralPhrase.getText()
+                    // trim whitespace characters before and after each item phrase
+                    .replaceAll("(?:\\s*(.+)\\s*\\n?)", "$1\n");
 
+                output.append(literalPhrases);
+            }
             output.append("<<<<<\n");
         }
 
@@ -353,7 +356,11 @@ public class SutrGenerator {
         }
 
         for (final SutrCustomTypeItem sutrCustomTypeItem : customTypeItemList) {
-            customTypeItemListBuilder.append(sutrCustomTypeItem.getText()).append("\n");
+            String customTypeItemText = sutrCustomTypeItem.getText()
+                // trim whitespace characters before and after each item phrase
+                .replaceAll("(?:\\s*(.+)\\s*\\n?)", "$1\n");
+
+            customTypeItemListBuilder.append(customTypeItemText);
         }
 
         return customTypeItemListBuilder;

--- a/src/com/slalom/aws/avs/sutr/conf/SutrConfigProvider.java
+++ b/src/com/slalom/aws/avs/sutr/conf/SutrConfigProvider.java
@@ -16,9 +16,9 @@ public class SutrConfigProvider {
 
     public static final String PROJECT_ROOT_TOKEN = "$PROJECT_ROOT$";
     public static final String DEFAULT_HANDLER_OUTPUT_PATH = PROJECT_ROOT_TOKEN + "/ask/";
-    private static final String DEFAULT_INTENT_OUTPUT_PATH = "$PROJECT_ROOT$/ask/intentName.json";
-    private static final String DEFAULT_UTTERANCE_OUTPUT_PATH = "$PROJECT_ROOT$/ask/skill.utr";
-    private static final String DEFAULT_CUSTOM_TYPES_OUTPUT_PATH = "$PROJECT_ROOT$/ask/custom.types";
+    private static final String DEFAULT_INTENT_OUTPUT_PATH = "$PROJECT_ROOT$/out/ask/intentName.json";
+    private static final String DEFAULT_UTTERANCE_OUTPUT_PATH = "$PROJECT_ROOT$/out/ask/skill.utr";
+    private static final String DEFAULT_CUSTOM_TYPES_OUTPUT_PATH = "$PROJECT_ROOT$/out/ask/custom.types";
     public static final String DEFAULT_PYTHON_TEMPLATE_PATH = "<Default Python>";
     public static final String DEFAULT_JAVASCRIPT_TEMPLATE_PATH = "<Default Javascript>";
 

--- a/src/com/slalom/aws/avs/sutr/conf/SutrRunConfigSettingsEditor.form
+++ b/src/com/slalom/aws/avs/sutr/conf/SutrRunConfigSettingsEditor.form
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.slalom.aws.avs.sutr.conf.SutrRunConfigSettingsEditor">
+  <grid id="27dc6" binding="myPanel" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+    <margin top="0" left="0" bottom="0" right="0"/>
+    <constraints>
+      <xy x="20" y="20" width="500" height="400"/>
+    </constraints>
+    <properties/>
+    <border type="none"/>
+    <children>
+      <component id="b488d" class="javax.swing.JLabel" binding="sutrFilesLabel">
+        <constraints>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <labelFor value="387d0"/>
+          <text value="Sutr Files"/>
+        </properties>
+      </component>
+      <vspacer id="1c418">
+        <constraints>
+          <grid row="1" column="0" row-span="1" col-span="2" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+        </constraints>
+      </vspacer>
+      <component id="387d0" class="javax.swing.JTextField" binding="sutrFilesTextField" default-binding="true">
+        <constraints>
+          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+            <preferred-size width="150" height="-1"/>
+          </grid>
+        </constraints>
+        <properties/>
+      </component>
+    </children>
+  </grid>
+</form>

--- a/src/com/slalom/aws/avs/sutr/conf/SutrRunConfigSettingsEditor.java
+++ b/src/com/slalom/aws/avs/sutr/conf/SutrRunConfigSettingsEditor.java
@@ -1,0 +1,32 @@
+package com.slalom.aws.avs.sutr.conf;
+
+import com.intellij.openapi.options.ConfigurationException;
+import com.intellij.openapi.options.SettingsEditor;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+
+/**
+ * Created by jordanc on 9/11/2016.
+ */
+public class SutrRunConfigSettingsEditor extends SettingsEditor<SutrRunConfiguration> {
+    private JPanel myPanel;
+    private JLabel sutrFilesLabel;
+    private JTextField sutrFilesTextField;
+
+    @Override
+    protected void resetEditorFrom(@NotNull SutrRunConfiguration sutrRunConfiguration) {
+        sutrFilesTextField.setText(sutrRunConfiguration.getIncludedSutrFilePattern());
+    }
+
+    @Override
+    protected void applyEditorTo(@NotNull SutrRunConfiguration sutrRunConfiguration) throws ConfigurationException {
+        sutrRunConfiguration.setIncludedSutrFilePattern(sutrFilesTextField.getText());
+    }
+
+    @NotNull
+    @Override
+    protected JComponent createEditor() {
+        return myPanel;
+    }
+}

--- a/src/com/slalom/aws/avs/sutr/conf/SutrRunConfigType.java
+++ b/src/com/slalom/aws/avs/sutr/conf/SutrRunConfigType.java
@@ -1,0 +1,40 @@
+package com.slalom.aws.avs.sutr.conf;
+
+import com.intellij.execution.configurations.ConfigurationFactory;
+import com.intellij.execution.configurations.ConfigurationType;
+import com.slalom.aws.avs.sutr.SutrIcons;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+
+/**
+ * Created by jordanc on 9/11/2016.
+ */
+public class SutrRunConfigType implements ConfigurationType {
+
+    @Override
+    public String getDisplayName() {
+        return "Sutr";
+    }
+
+    @Override
+    public String getConfigurationTypeDescription() {
+        return "Configures and generates a Sutr Ask model";
+    }
+
+    @Override
+    public Icon getIcon() {
+        return SutrIcons.FILE;
+    }
+
+    @NotNull
+    @Override
+    public String getId() {
+        return "SUTR_RUN_CONFIGURATION";
+    }
+
+    @Override
+    public ConfigurationFactory[] getConfigurationFactories() {
+        return new ConfigurationFactory[]{new SutrRunConfigurationFactory(this)};
+    }
+}

--- a/src/com/slalom/aws/avs/sutr/conf/SutrRunConfiguration.java
+++ b/src/com/slalom/aws/avs/sutr/conf/SutrRunConfiguration.java
@@ -1,0 +1,193 @@
+package com.slalom.aws.avs.sutr.conf;
+
+import com.intellij.execution.ExecutionException;
+import com.intellij.execution.Executor;
+import com.intellij.execution.configurations.*;
+import com.intellij.execution.process.*;
+import com.intellij.execution.runners.ExecutionEnvironment;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.options.SettingsEditor;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.InvalidDataException;
+import com.intellij.openapi.util.JDOMExternalizerUtil;
+import com.intellij.openapi.util.WriteExternalException;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiManager;
+import com.intellij.util.containers.ContainerUtil;
+import com.intellij.xdebugger.DefaultDebugProcessHandler;
+import com.slalom.aws.avs.sutr.actions.SutrGenerator;
+import com.slalom.aws.avs.sutr.actions.exceptions.SutrGeneratorException;
+import com.slalom.aws.avs.sutr.psi.SutrFile;
+import org.jdom.Element;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by jordanc on 9/11/2016.
+ */
+class SutrRunConfiguration extends RunConfigurationBase {
+    private String includedSutrFilePattern;
+
+    SutrRunConfiguration(Project project, ConfigurationFactory factory, String name) {
+        super(project, factory, name);
+    }
+
+    @NotNull
+    @Override
+    public SettingsEditor<? extends RunConfiguration> getConfigurationEditor() {
+        return new SutrRunConfigSettingsEditor();
+    }
+
+    @Override
+    public void checkConfiguration() throws RuntimeConfigurationException {
+    }
+
+    @Override
+    public void writeExternal(Element element) throws WriteExternalException {
+        super.writeExternal(element);
+        JDOMExternalizerUtil.addElementWithValueAttribute(element, "SUTR_FILES", getIncludedSutrFilePattern());
+    }
+
+    @Override
+    public void readExternal(@NotNull Element element) throws InvalidDataException {
+        super.readExternal(element);
+        setIncludedSutrFilePattern(JDOMExternalizerUtil.getFirstChildValueAttribute(element, "SUTR_FILES"));
+    }
+
+    @Nullable
+    @Override
+    public RunProfileState getState(@NotNull Executor executor, @NotNull ExecutionEnvironment executionEnvironment) throws ExecutionException {
+        return new SutrRunBuildState(executionEnvironment);
+    }
+
+    String getIncludedSutrFilePattern() {
+        return includedSutrFilePattern;
+    }
+
+    void setIncludedSutrFilePattern(String includedSutrFilePattern) {
+        this.includedSutrFilePattern = includedSutrFilePattern;
+    }
+
+    private class SutrRunBuildState extends CommandLineState {
+        private SutrRunBuildProcessHandler process;
+        private ExecutionEnvironment environment;
+
+        SutrRunBuildState(ExecutionEnvironment environment) {
+            super(environment);
+            this.environment = environment;
+        }
+
+        @NotNull
+        @Override
+        protected ProcessHandler startProcess() throws ExecutionException {
+            process = new SutrRunBuildProcessHandler();
+            ProcessTerminatedListener.attach(process);
+
+            ApplicationManager.getApplication().invokeLater(() -> {
+                message("Generating Sutr Ask Model...");
+
+                try {
+                    startBuild();
+                    message("Successfully generated Sutr Ask Model");
+                } catch (ExecutionException e) {
+                    e.printStackTrace();
+                    process.notifyTextAvailable("Failed to generate Sutr Ask Model: " + e, ProcessOutputTypes.STDERR);
+                    process.setExitCode(500);
+                }
+
+                process.destroyProcess();
+            });
+
+            return process;
+        }
+
+        private void message(String message) {
+            process.notifyTextAvailable(message + "\n", ProcessOutputTypes.STDOUT);
+        }
+
+        private void startBuild() throws ExecutionException {
+            Project project = environment.getProject();
+            ArrayList<VirtualFile> files = new ArrayList<>();
+
+            if (getIncludedSutrFilePattern() == null) {
+                return;
+            }
+
+            try {
+                final PathMatcher pathMatcher = FileSystems.getDefault().getPathMatcher("glob:" + getIncludedSutrFilePattern());
+
+                Files.walkFileTree(Paths.get(project.getBasePath()), new SimpleFileVisitor<Path>() {
+
+                    @Override
+                    public FileVisitResult visitFile(Path path, BasicFileAttributes attrs) throws IOException {
+                        if (pathMatcher.matches(path)) {
+                            message("Including file: " + path.toString());
+                            files.add(LocalFileSystem.getInstance().findFileByIoFile(path.toFile()));
+                        }
+                        return FileVisitResult.CONTINUE;
+                    }
+
+                    @Override
+                    public FileVisitResult visitFileFailed(Path file, IOException exc)
+                            throws IOException {
+                        return FileVisitResult.CONTINUE;
+                    }
+                });
+            } catch (IOException e) {
+                e.printStackTrace();
+                throw new ExecutionException(e);
+            }
+
+            final PsiManager manager = PsiManager.getInstance(project);
+            List<SutrFile> sutrFiles = ContainerUtil.mapNotNull(files, virtualFile -> {
+                PsiFile psiFile = manager.findFile(virtualFile);
+                return psiFile instanceof SutrFile ? (SutrFile) psiFile : null;
+            });
+
+            try {
+                SutrGenerator.genererateAsk(sutrFiles);
+            } catch (SutrGeneratorException e) {
+                e.printStackTrace();
+                throw new ExecutionException(e);
+            }
+        }
+
+        private class SutrRunBuildProcessHandler extends ProcessHandler {
+            private Integer myExitCode = 0;
+
+            void setExitCode(Integer exitCode) {
+                myExitCode = exitCode;
+            }
+
+            @Override
+            protected void destroyProcessImpl() {
+                this.notifyProcessTerminated(myExitCode);
+            }
+
+            @Override
+            protected void detachProcessImpl() {
+                this.notifyProcessDetached();
+            }
+
+            @Override
+            public boolean detachIsDefault() {
+                return false;
+            }
+
+            @Nullable
+            @Override
+            public OutputStream getProcessInput() {
+                return null;
+            }
+        }
+    }
+}

--- a/src/com/slalom/aws/avs/sutr/conf/SutrRunConfigurationFactory.java
+++ b/src/com/slalom/aws/avs/sutr/conf/SutrRunConfigurationFactory.java
@@ -1,0 +1,29 @@
+package com.slalom.aws.avs.sutr.conf;
+
+import com.intellij.execution.configurations.ConfigurationFactory;
+import com.intellij.execution.configurations.ConfigurationType;
+import com.intellij.execution.configurations.RunConfiguration;
+import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Created by jordanc on 9/11/2016.
+ */
+public class SutrRunConfigurationFactory extends ConfigurationFactory {
+    private static final String FACTORY_NAME = "Sutr Run Configuration Factory";
+
+    public SutrRunConfigurationFactory(ConfigurationType type) {
+        super(type);
+    }
+
+    @NotNull
+    @Override
+    public RunConfiguration createTemplateConfiguration(@NotNull Project project) {
+        return new SutrRunConfiguration(project, this, "Sutr");
+    }
+
+    @Override
+    public String getName() {
+        return FACTORY_NAME;
+    }
+}

--- a/src/com/slalom/aws/avs/sutr/mustache/SutrMustacheModelBuilder.java
+++ b/src/com/slalom/aws/avs/sutr/mustache/SutrMustacheModelBuilder.java
@@ -5,6 +5,7 @@ import com.github.mustachejava.Mustache;
 import com.github.mustachejava.MustacheFactory;
 import com.slalom.aws.avs.sutr.actions.SutrGenerator;
 import com.slalom.aws.avs.sutr.actions.exceptions.SutrGeneratorException;
+import com.slalom.aws.avs.sutr.conf.SutrConfigProvider;
 import com.slalom.aws.avs.sutr.mustache.models.SutrIntentModel;
 import com.slalom.aws.avs.sutr.mustache.models.SutrMustacheModel;
 import com.slalom.aws.avs.sutr.psi.SutrFile;
@@ -13,6 +14,7 @@ import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.StringWriter;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Created by stryderc on 6/9/2016.

--- a/src/com/slalom/aws/avs/sutr/psi/util/SutrPsiImplUtil.java
+++ b/src/com/slalom/aws/avs/sutr/psi/util/SutrPsiImplUtil.java
@@ -1,11 +1,17 @@
 package com.slalom.aws.avs.sutr.psi.util;
 
 import com.intellij.lang.ASTNode;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiDirectory;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiManager;
 import com.slalom.aws.avs.sutr.SutrLanguageType;
 import com.slalom.aws.avs.sutr.psi.*;
+
+import java.io.IOException;
+import java.nio.file.Paths;
 
 /**
  * Created by Stryder on 1/17/2016.
@@ -42,7 +48,22 @@ public class SutrPsiImplUtil {
         final PsiDirectory containingDirectory = importStmt.getContainingFile().getContainingDirectory();
 
         if (containingDirectory != null) {
-            PsiFile importFile = containingDirectory.findFile(fileName);
+            PsiManager psiManager = PsiManager.getInstance(importStmt.getProject());
+            String absoluteFileName;
+            try {
+                absoluteFileName = Paths.get(containingDirectory.getVirtualFile().getPath(), fileName)
+                    .toRealPath()
+                    .toString();
+            } catch (IOException e) {
+                return null;
+            }
+
+            VirtualFile virtualImportFile = LocalFileSystem.getInstance().findFileByPath(absoluteFileName);
+            PsiFile importFile = null;
+            if (virtualImportFile != null) {
+                importFile = psiManager.findFile(virtualImportFile);
+            }
+
             if (importFile != null) {
                 for (SutrTypeDefinitionReference sutrTypeDefinitionReference : ((SutrFile) importFile).findChildrenByClass(SutrTypeDefinitionReference.class)) {
                     if(sutrTypeDefinitionReference.getTypeName().getText().equals(importStmt.getTypeName().getText())){


### PR DESCRIPTION
Most of the changes are related to adding a configuration, but there are some other minor improvements including:
- Sutr run configuration which allows the "Generate Ask" action to be performed as part of a build
  - set the "Sutr Files" property to a glob path (e.g. "*_/path/to/sutr/files/_.sutr")
  - NOTE: there is an existing bug that causes duplicate definition errors if you include imported files as part of a generate Ask files.  Workaround: only include the files that do the importing (i.e. the "intent" files)
- You can now import sutr files with a relative path!
